### PR TITLE
Track migration flow

### DIFF
--- a/ajax/backup.php
+++ b/ajax/backup.php
@@ -37,24 +37,10 @@ try {
 		App::log('Invalid response from update feed.');
 		throw new \Exception((string) App::$l10n->t('Version not found'));
 	}
-	
+
 	$packageVersionArray = explode('.', $packageVersion);
-	$currentVersionArray = \OC_Util::getVersion();
-	$currentVersion = \OC_Util::getVersionString();
-	$difference = intval($packageVersionArray[0]) - intval($currentVersionArray[0]);
-	if ($difference>1 || $difference<0 || version_compare($currentVersion, $packageVersion) > 0) {
-		$message = (string) App::$l10n->t(
-			'Not possible to update %s to %s. Downgrading or skipping major releases is not supported.', 
-			array(
-				$currentVersion,
-				implode('.', $packageVersionArray)
-			)
-		); 
-		App::log($message);
-		throw new \Exception($message);
-	}
-	
-	
+	Helper::checkVersion($packageVersionArray, $packageVersion);
+
 	//Some cleanup first
 	Downloader::cleanUp($packageVersion);
 	if (!Downloader::isClean($packageVersion)){

--- a/lib/downloader.php
+++ b/lib/downloader.php
@@ -69,6 +69,9 @@ class Downloader {
 			throw new \Exception(self::$package . " extraction error. " . $hint);
 		}
 
+		include $baseDir . '/version.php';
+		Helper::checkVersion($OC_Version, $OC_VersionString);
+
 		$sources = Helper::getSources($version);
 		rename($baseDir . '/' . Helper::THIRDPARTY_DIRNAME, $sources[Helper::THIRDPARTY_DIRNAME]);
 		rename($baseDir . '/' . Helper::APP_DIRNAME, $sources[Helper::APP_DIRNAME]);

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -16,7 +16,25 @@ class Helper {
 	const APP_DIRNAME = 'apps';
 	const THIRDPARTY_DIRNAME = '3rdparty';
 	const CORE_DIRNAME = 'core';
-	
+
+	public static function checkVersion($newVersionArray, $newVersionString){
+		$currentVersionArray = \OC_Util::getVersion();
+		$currentVersion = \OC_Util::getVersionString();
+
+		$difference = intval($newVersionArray[0]) - intval($currentVersionArray[0]);
+		if ($difference>1 || $difference<0 || version_compare($currentVersion, $newVersionString) > 0) {
+			$message = (string) App::$l10n->t(
+				'Not possible to update %s to %s. Downgrading or skipping major releases is not supported.', 
+				array(
+					$currentVersion,
+					implode('.', $newVersionArray)
+				)
+			); 
+			App::log($message);
+			throw new \Exception($message);
+		}
+	}
+
 	/**
 	 * Moves file/directory
 	 * @param string $src  - source path


### PR DESCRIPTION
Prevents unsupported migrations by comparing the current version with versions returned by update feed and package version file.

Ref https://github.com/owncloud/core/issues/11078
