### PR TITLE
fix updater URL to https

### DIFF
--- a/update.php
+++ b/update.php
@@ -25,7 +25,7 @@ if (!@file_exists(App::getBackupBase())){
 }
 
 $updater = new \OC\Updater();
-$data = $updater->check('http://apps.owncloud.com/updater.php');
+$data = $updater->check('https://apps.owncloud.com/updater.php');
 $isNewVersionAvailable = isset($data['version']) && $data['version'] != '' && $data['version'] !== Array();
 
 $tmpl = new \OCP\Template(App::APP_ID, 'update', 'guest');


### PR DESCRIPTION
I think that the solution described in owncloud/core#12932 by adding `openssl.cafile` to `php.ini` only masks the real problem.
Agreed, it will fix the openssl error. But for some reason the redirect still doesn't work as expected. In any case, there's no harm in changing the URL to the correct scheme. Another pro: one less redirect.