### PR TITLE
fix(Helper::move): use `copyr -> rmdirr` for dirs

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -42,7 +42,11 @@ class Helper {
 	 * @throws \Exception on error
 	 */
 	public static function move($src, $dest) {
-		if (!rename($src, $dest)) {
+		if (is_dir($src)) {
+			self::copyr($src, $dest);
+			self::rmdirr($src);
+		}
+		elseif (!rename($src, $dest)) {
 			throw new \Exception("Unable to move $src to $dest");
 		}
 	}


### PR DESCRIPTION
`rename` is unable to move directories across filesystems

see https://bugs.php.net/bug.php?id=54097