### PR TITLE
[stable 8.1] Remove bogus redundant version number

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,7 +3,6 @@
 	<id>updater</id>
 	<name>Updater</name>
 	<description>ownCloud updater plugin. Check README for details.</description>
-	<version>0.5</version>
 	<licence>AGPL</licence>
 	<author>Victor Dubiniuk</author>
 	<bugs>https://github.com/owncloud/updater/issues</bugs>


### PR DESCRIPTION
Backport of the version number fix https://github.com/owncloud/updater/pull/154

@VicDeo 