### PR TITLE
Only do a scandir if the folder exists

### DIFF
--- a/src/Tests/Utils/CheckpointTest.php
+++ b/src/Tests/Utils/CheckpointTest.php
@@ -7,7 +7,7 @@ use Owncloud\Updater\Utils\FilesystemHelper;
 use Owncloud\Updater\Utils\Locator;
 
 class CheckpointTest extends \PHPUnit_Framework_TestCase {
-	public function testGetAll(){
+	public function testGetAll() {
 		$checkpointList = ['a', 'b', 'c'];
 		$fsHelper = $this->getMockBuilder('Owncloud\Updater\Utils\FilesystemHelper')
 				->disableOriginalConstructor()
@@ -15,6 +15,9 @@ class CheckpointTest extends \PHPUnit_Framework_TestCase {
 		;
 		$fsHelper->method('scandir')
 				->willReturn($checkpointList)
+		;
+		$fsHelper->method('isDir')
+			->willReturn(true)
 		;
 		$locator = $this->getMockBuilder('Owncloud\Updater\Utils\Locator')
 				->disableOriginalConstructor()
@@ -25,7 +28,26 @@ class CheckpointTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($checkpointList, $actual);
 	}
 
-
+	public function testGetAllWithNotExistingFolder() {
+		$checkpointList = ['a', 'b', 'c'];
+		$fsHelper = $this->getMockBuilder('Owncloud\Updater\Utils\FilesystemHelper')
+			->disableOriginalConstructor()
+			->getMock()
+		;
+		$fsHelper->method('scandir')
+			->willReturn($checkpointList)
+		;
+		$fsHelper->method('isDir')
+			->willReturn(false)
+		;
+		$locator = $this->getMockBuilder('Owncloud\Updater\Utils\Locator')
+			->disableOriginalConstructor()
+			->getMock()
+		;
+		$checkpointMock = $this->getCheckpointInstance($locator, $fsHelper);
+		$actual = $checkpointMock->getAll();
+		$this->assertEquals([], $actual);
+	}
 
 	protected function getCheckpointInstance(Locator $locator, FilesystemHelper $fsHelper){
 		return new Checkpoint($locator, $fsHelper);

--- a/src/Utils/Checkpoint.php
+++ b/src/Utils/Checkpoint.php
@@ -107,7 +107,7 @@ class Checkpoint {
 
 	public function getAll(){
 		$checkpointDir = $this->locator->getCheckpointDir();
-		$content = $this->fsHelper->scandir($checkpointDir);
+		$content = $this->fsHelper->isDir($checkpointDir) ? $this->fsHelper->scandir($checkpointDir) : [];
 		$checkpoints = array_filter(
 				$content,
 				function($dir){

--- a/src/Utils/FilesystemHelper.php
+++ b/src/Utils/FilesystemHelper.php
@@ -51,6 +51,15 @@ class FilesystemHelper {
 	}
 
 	/**
+	 * Wrapper for is_dir function
+	 * @param string $path
+	 * @return bool
+	 */
+	public function isDir($path){
+		return is_dir($path);
+	}
+
+	/**
 	 * Wrapper for md5_file function
 	 * @param string $path
 	 * @return string


### PR DESCRIPTION
Depending on the PHP config this looks otherwise like that and is broken:

![2016-02-08_23-22-25](https://cloud.githubusercontent.com/assets/878997/12901248/d3aed87a-ceba-11e5-80c7-220f7bc5edf8.png)
