### PR TITLE
Add authentication to updater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "guzzlehttp/guzzle": "^5.3.0",
         "psr/log": "^1.0",
         "league/plates": "^3.1",
-        "paragonie/random_compat": "^1.2"
+        "paragonie/random_compat": "^1.2",
+        "symfony/polyfill-php56": "^1.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d9f8f8e1e6039395b8a8d3a5404098e1",
-    "content-hash": "ad920c54f395c7b17606845014d1e849",
+    "hash": "2686e668669b3d393c256c6dd9ad4c46",
+    "content-hash": "95b19563e5cac4dcb13f0767ada096fa",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -449,6 +449,114 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2015-10-20 14:38:46"
+        },
+        {
+            "name": "symfony/polyfill-php56",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php56.git",
+                "reference": "4d891fff050101a53a4caabb03277284942d1ad9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/4d891fff050101a53a4caabb03277284942d1ad9",
+                "reference": "4d891fff050101a53a4caabb03277284942d1ad9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-util": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php56\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
+        },
+        {
+            "name": "symfony/polyfill-util",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-util.git",
+                "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
+                "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Util\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony utilities for portability of PHP codes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compat",
+                "compatibility",
+                "polyfill",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
         },
         {
             "name": "symfony/process",

--- a/pub/js/login.js
+++ b/pub/js/login.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016
+ *  Lukas Reschke <lukas@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or later.
+ * See the COPYING-README file.
+ */
+
+var OC = {};
+var loginToken;
+
+(function(OC) {
+	OC.Login = OC.Login || {};
+
+	OC.Login = {
+		onLogin: function () {
+			loginToken = $('#password').val();
+			$.ajax({
+				url: '.',
+				headers: {
+					'Authorization': loginToken,
+				},
+				method: 'POST',
+				success: function(data){
+					if(data !== 'false') {
+						var body = $('body');
+						body.html(data);
+						body.removeAttr('id');
+						body.attr('id', 'body-settings');
+					} else  {
+						$('#invalidPasswordWarning').show();
+					}
+				}
+			});
+
+			return false;
+		}
+	}
+
+})(OC);
+
+$(document).ready(function() {
+	$('form[name=login]').submit(OC.Login.onLogin);
+});

--- a/pub/js/main.js
+++ b/pub/js/main.js
@@ -1,10 +1,7 @@
 $(function () {
-	//pass a token with any post request
-	$.ajaxPrefilter(function (options, originalOptions, jqXHR) {
-		if (originalOptions.type !== 'post' || options.type !== 'post') {
-			return;
-		}
-		options.data = $.param($.extend(originalOptions.data, {token: $('head').attr('data-requesttoken')}));
+	// Pass the auth token with any request
+	$.ajaxSetup({
+		headers: { 'Authorization': loginToken }
 	});
 
 	// Setup a global AJAX error handler

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -33,5 +33,14 @@ class Request {
 		return isset($this->vars['post'][$parameter]) ? $this->vars['post'][$parameter] : null;
 	}
 
+	/**
+	 * @param string$name
+	 * @return mixed
+	 */
+	public function header($name) {
+		$name = strtoupper($name);
+		return isset($this->vars['headers']['HTTP_'.$name]) ? $this->vars['headers']['HTTP_'.$name] : null;
+	}
+
 }
 

--- a/src/Resources/views/base.php
+++ b/src/Resources/views/base.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--[if IE 9]><html class="ng-csp ie ie9 lte9" data-placeholder-focus="false" lang="en" ><![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--><html class="ng-csp" data-placeholder-focus="false" lang="en" ><!--<![endif]-->
-	<head data-requesttoken="<?=$this->e($token)?>">
+	<head>
 		<meta charset="utf-8">
 		<title>ownCloud	Updater - <?=$this->e($title)?></title>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -9,7 +9,6 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
 		<link rel="stylesheet" href="<?=$this->uri() . '/pub/' . $this->asset('css/main.css')?>" />
 		<script src="<?=$this->uri() . '/pub/' . $this->asset('js/vendor/jquery.min.js')?>"></script>
-		<script src="<?=$this->uri() . '/pub/' . $this->asset('js/main.js')?>"></script>
 	</head>
 	<body id="<?=$this->e($bodyId)?>">
 		<noscript>

--- a/src/Resources/views/partials/inner.php
+++ b/src/Resources/views/partials/inner.php
@@ -1,5 +1,4 @@
-<?php $this->layout('base', ['title' => $title, 'bodyId' => 'body-settings', 'token' => $token]) ?>
-<?php $this->start('inner') ?>
+<script src="<?=$this->uri() . '/pub/' . $this->asset('js/main.js')?>"></script>
 <header role="banner"><div id="header">
 		<a href="#" id="owncloud" tabindex="1">
 			<div class="logo-icon svg">
@@ -95,4 +94,3 @@
 		</div>
 	</div>
 </div>
-<?php $this->stop() ?>

--- a/src/Resources/views/partials/login.php
+++ b/src/Resources/views/partials/login.php
@@ -1,6 +1,6 @@
-<?php $this->layout('base', ['title' => $title, 'token'=>$token]) ?>
-
+<?php $this->layout('base', ['title' => $title, 'bodyId' => 'body-login']) ?>
 <?php $this->start('login') ?>
+	<script src="<?=$this->uri() . '/pub/' . $this->asset('js/login.js')?>"></script>
 		<div class="wrapper">
 			<div class="v-align">
 				<header role="banner">
@@ -11,31 +11,18 @@
 						<div id="logo-claim" style="display:none;"></div>
 					</div>
 				</header>
+
+				<br/>
+
+				<p style="text-align: left; display: none;" id="invalidPasswordWarning">Invalid password</p>
+				<p style="text-align: left">Please provide the "updater.secret" from your ownCloud's config/config.php:</p>
 				<form method="post" name="login">
 					<fieldset>
-						<div id="message" class="hidden">
-							<img class="float-spinner" alt=""
-								 src="pub/<?=$this->asset('img/loading-dark.gif')?>">
-							<span id="messageText"></span>
-							<!-- the following div ensures that the spinner is always inside the #message div -->
-							<div style="clear: both;"></div>
-						</div>
-						<p class="grouptop">
-							<input type="text" name="user" id="user"
-								   placeholder="Username"
-								   value="<?=$this->e($username)?>"
-								   autofocus				autocomplete="on" autocapitalize="off" autocorrect="off" required>
-							<label for="user" class="infield">Username</label>
-						</p>
-
-						<p class="groupbottom">
-							<input type="password" name="password" id="password" value="<?=$this->e($password)?>"
-								   placeholder="Password"
-								   autocomplete="on" autocapitalize="off" autocorrect="off" required>
-							<label for="password" class="infield">Password</label>
-							<input type="submit" id="submit" class="login primary icon-confirm svg" title="Log in" value="" disabled="disabled"/>
-						</p>
-						<input type="hidden" name="requesttoken" value="<?=$this->e($token)?>">
+						<input type="password" name="password" id="password" value=""
+							   placeholder="Secret"
+							   autocomplete="on" autocapitalize="off" autocorrect="off" required>
+						<label for="password" class="infield">Password</label>
+						<input type="submit" id="submit" class="login primary icon-confirm svg" title="Log in" value="" />
 					</fieldset>
 				</form>
 				<div class="push"></div><!-- for sticky footer -->
@@ -43,6 +30,7 @@
 		</div>
 		<footer role="contentinfo">
 			<p class="info">
-				<a href="https://owncloud.org" target="_blank" rel="noreferrer">ownCloud</a> – web services under your control			</p>
+				<a href="https://owncloud.org" target="_blank" rel="noreferrer">ownCloud</a> – web services under your control
+			</p>
 		</footer>
 <?php $this->stop() ?>

--- a/src/Utils/ConfigReader.php
+++ b/src/Utils/ConfigReader.php
@@ -91,7 +91,7 @@ class ConfigReader {
 	 * @throws \UnexpectedValueException
 	 */
 	private function load(){
-		$this->cache = $this->occRunner->runJson('config:list');
+		$this->cache = $this->occRunner->runJson('config:list --private');
 	}
 
 }

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -8,4 +8,5 @@ $baseDir = dirname($vendorDir);
 return array(
     'ad155f8f1cf0d418fe49e248db8c661b' => $vendorDir . '/react/promise/src/functions_include.php',
     '5255c38a0faeba867671b61dfda6d864' => $vendorDir . '/paragonie/random_compat/lib/random.php',
+    'bd9634f2d41831496de0d3dfe4c94881' => $vendorDir . '/symfony/polyfill-php56/bootstrap.php',
 );

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -6,6 +6,8 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'Symfony\\Polyfill\\Util\\' => array($vendorDir . '/symfony/polyfill-util'),
+    'Symfony\\Polyfill\\Php56\\' => array($vendorDir . '/symfony/polyfill-php56'),
     'Symfony\\Component\\Process\\' => array($vendorDir . '/symfony/process'),
     'Symfony\\Component\\Console\\' => array($vendorDir . '/symfony/console'),
     'React\\Promise\\' => array($vendorDir . '/react/promise/src'),

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -507,5 +507,117 @@
             "pseudorandom",
             "random"
         ]
+    },
+    {
+        "name": "symfony/polyfill-util",
+        "version": "v1.1.0",
+        "version_normalized": "1.1.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/polyfill-util.git",
+            "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
+            "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.3"
+        },
+        "time": "2016-01-20 09:13:37",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.1-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Polyfill\\Util\\": ""
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony utilities for portability of PHP codes",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "compat",
+            "compatibility",
+            "polyfill",
+            "shim"
+        ]
+    },
+    {
+        "name": "symfony/polyfill-php56",
+        "version": "v1.1.0",
+        "version_normalized": "1.1.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/polyfill-php56.git",
+            "reference": "4d891fff050101a53a4caabb03277284942d1ad9"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/4d891fff050101a53a4caabb03277284942d1ad9",
+            "reference": "4d891fff050101a53a4caabb03277284942d1ad9",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.3",
+            "symfony/polyfill-util": "~1.0"
+        },
+        "time": "2016-01-20 09:13:37",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.1-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Polyfill\\Php56\\": ""
+            },
+            "files": [
+                "bootstrap.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "compatibility",
+            "polyfill",
+            "portable",
+            "shim"
+        ]
     }
 ]

--- a/vendor/symfony/polyfill-php56/LICENSE
+++ b/vendor/symfony/polyfill-php56/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014-2016 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/symfony/polyfill-php56/Php56.php
+++ b/vendor/symfony/polyfill-php56/Php56.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php56;
+
+use Symfony\Polyfill\Util\Binary;
+
+/**
+ * @internal
+ */
+final class Php56
+{
+    const LDAP_ESCAPE_FILTER = 1;
+    const LDAP_ESCAPE_DN = 2;
+
+    public static function hash_equals($knownString, $userInput)
+    {
+        if (!is_string($knownString)) {
+            trigger_error('Expected known_string to be a string, '.gettype($knownString).' given', E_USER_WARNING);
+
+            return false;
+        }
+
+        if (!is_string($userInput)) {
+            trigger_error('Expected user_input to be a string, '.gettype($userInput).' given', E_USER_WARNING);
+
+            return false;
+        }
+
+        $knownLen = Binary::strlen($knownString);
+        $userLen = Binary::strlen($userInput);
+
+        if ($knownLen !== $userLen) {
+            return false;
+        }
+
+        $result = 0;
+
+        for ($i = 0; $i < $knownLen; ++$i) {
+            $result |= ord($knownString[$i]) ^ ord($userInput[$i]);
+        }
+
+        return 0 === $result;
+    }
+
+    /**
+     * Stub implementation of the {@link ldap_escape()} function of the ldap
+     * extension.
+     *
+     * Escape strings for safe use in LDAP filters and DNs.
+     *
+     * @author Chris Wright <ldapi@daverandom.com>
+     *
+     * @param string $subject
+     * @param string $ignore
+     * @param int    $flags
+     *
+     * @return string
+     *
+     * @see http://stackoverflow.com/a/8561604
+     */
+    public static function ldap_escape($subject, $ignore = '', $flags = 0)
+    {
+        static $charMaps = null;
+
+        if (null === $charMaps) {
+            $charMaps = array(
+                self::LDAP_ESCAPE_FILTER => array('\\', '*', '(', ')', "\x00"),
+                self::LDAP_ESCAPE_DN => array('\\', ',', '=', '+', '<', '>', ';', '"', '#'),
+            );
+
+            $charMaps[0] = array();
+
+            for ($i = 0; $i < 256; ++$i) {
+                $charMaps[0][chr($i)] = sprintf('\\%02x', $i);
+            }
+
+            for ($i = 0, $l = count($charMaps[self::LDAP_ESCAPE_FILTER]); $i < $l; ++$i) {
+                $chr = $charMaps[self::LDAP_ESCAPE_FILTER][$i];
+                unset($charMaps[self::LDAP_ESCAPE_FILTER][$i]);
+                $charMaps[self::LDAP_ESCAPE_FILTER][$chr] = $charMaps[0][$chr];
+            }
+
+            for ($i = 0, $l = count($charMaps[self::LDAP_ESCAPE_DN]); $i < $l; ++$i) {
+                $chr = $charMaps[self::LDAP_ESCAPE_DN][$i];
+                unset($charMaps[self::LDAP_ESCAPE_DN][$i]);
+                $charMaps[self::LDAP_ESCAPE_DN][$chr] = $charMaps[0][$chr];
+            }
+        }
+
+        // Create the base char map to escape
+        $flags = (int) $flags;
+        $charMap = array();
+
+        if ($flags & self::LDAP_ESCAPE_FILTER) {
+            $charMap += $charMaps[self::LDAP_ESCAPE_FILTER];
+        }
+
+        if ($flags & self::LDAP_ESCAPE_DN) {
+            $charMap += $charMaps[self::LDAP_ESCAPE_DN];
+        }
+
+        if (!$charMap) {
+            $charMap = $charMaps[0];
+        }
+
+        // Remove any chars to ignore from the list
+        $ignore = (string) $ignore;
+
+        for ($i = 0, $l = strlen($ignore); $i < $l; ++$i) {
+            unset($charMap[$ignore[$i]]);
+        }
+
+        // Do the main replacement
+        $result = strtr($subject, $charMap);
+
+        return $result;
+    }
+}

--- a/vendor/symfony/polyfill-php56/README.md
+++ b/vendor/symfony/polyfill-php56/README.md
@@ -1,0 +1,15 @@
+Symfony Polyfill / Php56
+========================
+
+This component provides functions unavailable in releases prior to PHP 5.6:
+
+- [`hash_equals`](http://php.net/hash_equals)  (part of [hash](http://php.net/hash) extension)
+- [`ldap_escape`](http://php.net/ldap_escape) (part of [ldap](http://php.net/ldap) extension)
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/vendor/symfony/polyfill-php56/bootstrap.php
+++ b/vendor/symfony/polyfill-php56/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php56 as p;
+
+if (PHP_VERSION_ID < 50600) {
+    if (!function_exists('hash_equals')) {
+        function hash_equals($knownString, $userInput) { return p\Php56::hash_equals($knownString, $userInput); }
+    }
+    if (extension_loaded('ldap') && !function_exists('ldap_escape')) {
+        define('LDAP_ESCAPE_FILTER', 1);
+        define('LDAP_ESCAPE_DN', 2);
+
+        function ldap_escape($subject, $ignore = '', $flags = 0) { return p\Php56::ldap_escape($subject, $ignore, $flags); }
+    }
+
+    if (50509 === PHP_VERSION_ID && 4 === PHP_INT_SIZE) {
+        // Missing functions in PHP 5.5.9 - affects 32 bit builds of Ubuntu 14.04LTS
+        // See https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1315888
+        if (!function_exists('gzopen') && function_exists('gzopen64')) {
+            function gzopen($filename, $mode, $use_include_path = 0) { return gzopen64($filename, $mode, $use_include_path); }
+        }
+        if (!function_exists('gzseek') && function_exists('gzseek64')) {
+            function gzseek($zp, $offset, $whence = SEEK_SET) { return gzseek64($zp, $offset, $whence); }
+        }
+        if (!function_exists('gztell') && function_exists('gztell64')) {
+            function gztell($zp) { return gztell64($zp); }
+        }
+    }
+}

--- a/vendor/symfony/polyfill-php56/composer.json
+++ b/vendor/symfony/polyfill-php56/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "symfony/polyfill-php56",
+    "type": "library",
+    "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+    "keywords": ["polyfill", "shim", "compatibility", "portable"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3",
+        "symfony/polyfill-util": "~1.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Polyfill\\Php56\\": "" },
+        "files": [ "bootstrap.php" ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1-dev"
+        }
+    }
+}

--- a/vendor/symfony/polyfill-util/Binary.php
+++ b/vendor/symfony/polyfill-util/Binary.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+if (extension_loaded('mbstring')) {
+    class Binary extends BinaryOnFuncOverload {}
+} else {
+    class Binary extends BinaryNoFuncOverload {}
+}

--- a/vendor/symfony/polyfill-util/BinaryNoFuncOverload.php
+++ b/vendor/symfony/polyfill-util/BinaryNoFuncOverload.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class BinaryNoFuncOverload
+{
+    public static function strlen($s)
+    {
+        return strlen($s);
+    }
+
+    public static function strpos($haystack, $needle, $offset = 0)
+    {
+        return strpos($haystack, $needle, $offset);
+    }
+
+    public static function strrpos($haystack, $needle, $offset = 0)
+    {
+        return strrpos($haystack, $needle, $offset);
+    }
+
+    public static function substr($string, $start, $length = PHP_INT_MAX)
+    {
+        return substr($string, $start, $length);
+    }
+
+    public static function stripos($s, $needle, $offset = 0)
+    {
+        return stripos($s, $needle, $offset);
+    }
+
+    public static function stristr($s, $needle, $part = false)
+    {
+        return stristr($s, $needle, $part);
+    }
+
+    public static function strrchr($s, $needle, $part = false)
+    {
+        return strrchr($s, $needle, $part);
+    }
+
+    public static function strripos($s, $needle, $offset = 0)
+    {
+        return strripos($s, $needle, $offset);
+    }
+
+    public static function strstr($s, $needle, $part = false)
+    {
+        return strstr($s, $needle, $part);
+    }
+}

--- a/vendor/symfony/polyfill-util/BinaryOnFuncOverload.php
+++ b/vendor/symfony/polyfill-util/BinaryOnFuncOverload.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+/**
+ * Binary safe version of string functions overloaded when MB_OVERLOAD_STRING is enabled.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class BinaryOnFuncOverload
+{
+    public static function strlen($s)
+    {
+        return mb_strlen($s, '8bit');
+    }
+
+    public static function strpos($haystack, $needle, $offset = 0)
+    {
+        return mb_strpos($haystack, $needle, $offset, '8bit');
+    }
+
+    public static function strrpos($haystack, $needle, $offset = 0)
+    {
+        return mb_strrpos($haystack, $needle, $offset, '8bit');
+    }
+
+    public static function substr($string, $start, $length = 2147483647)
+    {
+        return mb_substr($string, $start, $length, '8bit');
+    }
+
+    public static function stripos($s, $needle, $offset = 0)
+    {
+        return mb_stripos($s, $needle, $offset, '8bit');
+    }
+
+    public static function stristr($s, $needle, $part = false)
+    {
+        return mb_stristr($s, $needle, $part, '8bit');
+    }
+
+    public static function strrchr($s, $needle, $part = false)
+    {
+        return mb_strrchr($s, $needle, $part, '8bit');
+    }
+
+    public static function strripos($s, $needle, $offset = 0)
+    {
+        return mb_strripos($s, $needle, $offset, '8bit');
+    }
+
+    public static function strstr($s, $needle, $part = false)
+    {
+        return mb_strstr($s, $needle, $part, '8bit');
+    }
+}

--- a/vendor/symfony/polyfill-util/LICENSE
+++ b/vendor/symfony/polyfill-util/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014-2016 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/symfony/polyfill-util/README.md
+++ b/vendor/symfony/polyfill-util/README.md
@@ -1,0 +1,13 @@
+Symfony Polyfill / Util
+=======================
+
+This component provides binary-safe string functions, using the
+[mbstring](https://php.net/mbstring) extension when available.
+
+More information can be found in the
+[main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).
+
+License
+=======
+
+This library is released under the [MIT license](LICENSE).

--- a/vendor/symfony/polyfill-util/TestListener.php
+++ b/vendor/symfony/polyfill-util/TestListener.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class TestListener extends \PHPUnit_Framework_TestSuite implements \PHPUnit_Framework_TestListener
+{
+    public static $enabledPolyfills;
+    private $suite;
+
+    public function __construct(\PHPUnit_Framework_TestSuite $suite = null)
+    {
+        if ($suite) {
+            $this->suite = $suite;
+            $this->setName($suite->getName().' with polyfills enabled');
+            $this->addTest($suite);
+        }
+    }
+
+    public function startTestSuite(\PHPUnit_Framework_TestSuite $mainSuite)
+    {
+        if (null !== self::$enabledPolyfills) {
+            return;
+        }
+        self::$enabledPolyfills = false;
+
+        foreach ($mainSuite->tests() as $suite) {
+            $testClass = $suite->getName();
+            if (!$tests = $suite->tests()) {
+                continue;
+            }
+            if (!preg_match('/^(.+)\\\\Tests(\\\\.*)Test$/', $testClass, $m)) {
+                $mainSuite->addTest(self::warning('Unknown naming convention for '.$testClass));
+                continue;
+            }
+            if (!class_exists($m[1].$m[2])) {
+                continue;
+            }
+            $testedClass = new \ReflectionClass($m[1].$m[2]);
+            $bootstrap = new \SplFileObject(dirname($testedClass->getFileName()).'/bootstrap.php');
+            $warnings = array();
+            $defLine = null;
+
+            foreach (new \RegexIterator($bootstrap, '/return p\\\\'.$testedClass->getShortName().'::/') as $defLine) {
+                if (!preg_match('/^\s*function (?P<name>[^\(]++)(?P<signature>\([^\)]*+\)) \{ (?<return>return p\\\\'.$testedClass->getShortName().'::[^\(]++)(?P<args>\([^\)]*+\)); \}$/', $defLine, $f)) {
+                    $warnings[] = self::warning('Invalid line in bootstrap.php: '.trim($defLine));
+                    continue;
+                }
+                $testNamespace = substr($testClass, 0, strrpos($testClass, '\\'));
+                if (function_exists($testNamespace.'\\'.$f['name'])) {
+                    continue;
+                }
+
+                try {
+                    $r = new \ReflectionFunction($f['name']);
+                    if ($r->isUserDefined()) {
+                        throw new \ReflectionException();
+                    }
+                    if (false !== strpos($f['signature'], '&')) {
+                        $defLine = sprintf('return \\%s%s', $f['name'], $f['args']);
+                    } else {
+                        $defLine = sprintf("return \\call_user_func_array('%s', func_get_args())", $f['name']);
+                    }
+                } catch (\ReflectionException $e) {
+                    $defLine = sprintf("throw new \PHPUnit_Framework_SkippedTestError('Internal function not found: %s')", $f['name']);
+                }
+
+                eval(<<<EOPHP
+namespace {$testNamespace};
+
+use Symfony\Polyfill\Util\TestListener;
+use {$testedClass->getNamespaceName()} as p;
+
+function {$f['name']}{$f['signature']}
+{
+    if ('{$testClass}' === TestListener::\$enabledPolyfills) {
+        {$f['return']}{$f['args']};
+    }
+
+    {$defLine};
+}
+EOPHP
+                );
+            }
+            if (!$warnings && null === $defLine) {
+                $warnings[] = new \PHPUnit_Framework_SkippedTestCase('No Polyfills found in bootstrap.php for '.$testClass);
+            } else {
+                $mainSuite->addTest(new static($suite));
+            }
+        }
+        foreach ($warnings as $w) {
+            $mainSuite->addTest($w);
+        }
+    }
+
+    protected function setUp()
+    {
+        self::$enabledPolyfills = $this->suite->getName();
+    }
+
+    protected function tearDown()
+    {
+        self::$enabledPolyfills = false;
+    }
+
+    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+        if (false !== self::$enabledPolyfills) {
+            $r = new \ReflectionProperty('Exception', 'message');
+            $r->setAccessible(true);
+            $r->setValue($e, 'Polyfills enabled, '.$r->getValue($e));
+        }
+    }
+
+    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+    {
+        $this->addError($test, $e, $time);
+    }
+
+    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    {
+    }
+
+    public function startTest(\PHPUnit_Framework_Test $test)
+    {
+    }
+
+    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    {
+    }
+}

--- a/vendor/symfony/polyfill-util/composer.json
+++ b/vendor/symfony/polyfill-util/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "symfony/polyfill-util",
+    "type": "library",
+    "description": "Symfony utilities for portability of PHP codes",
+    "keywords": ["polyfill", "shim", "compat", "compatibility"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Polyfill\\Util\\": "" }
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1-dev"
+        }
+    }
+}


### PR DESCRIPTION
This adds some authentication to the updater using a shared secret in `config.php`. The whole process is cookieless and thus if somebody closes the tab all authentication is gone (which is desired from a security PoV)

To test this define an `updater.secret` in `config.php` and try to access it with a valid or invalid token.

The next step is to add the automagic login from core once this is in. We can do that using the new updatenotification app at https://github.com/owncloud/core/pull/22238.

@VicDeo Please review.