### PR TITLE
Proper error message when /updater is browsed directly.

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -96,7 +96,7 @@ class IndexController {
 		$configReader->init();
 		$storedSecret = isset($configReader->get(['system'])['updater.secret']) ? $configReader->get(['system'])['updater.secret'] : null;
 		if(is_null($storedSecret)) {
-			die('updater.secret is undefined in config/config.php. Please define a strong secret using bcrypt("SecretToken").');
+			die('updater.secret is undefined in config/config.php. Either browse the admin settings in your ownCloud and click "Open updater" or define a strong secret using <pre>php -r \'echo password_hash("MyStrongSecretDoUseYourOwn!", PASSWORD_DEFAULT)."\n";\'</pre> and set this in the config.php.');
 		}
 		$sentAuthHeader = ($this->request->header('Authorization') !== null) ? $this->request->header('Authorization') : '';
 


### PR DESCRIPTION
* fixes #253

cc @LukasReschke @karlitschek @VicDeo 


Looks like this:

<img width="1037" alt="bildschirmfoto 2016-02-26 um 10 35 05" src="https://cloud.githubusercontent.com/assets/245432/13348587/aa60545e-dc74-11e5-91c1-a4945b90087b.png">
