### PR TITLE
[stable9] Use custom header

### DIFF
--- a/pub/js/login.js
+++ b/pub/js/login.js
@@ -17,7 +17,7 @@ var loginToken;
 			$.ajax({
 				url: '.',
 				headers: {
-					'Authorization': loginToken,
+					'X-Updater-Auth': loginToken,
 				},
 				method: 'POST',
 				success: function(data){

--- a/pub/js/main.js
+++ b/pub/js/main.js
@@ -1,7 +1,7 @@
 $(function () {
 	// Pass the auth token with any request
 	$.ajaxSetup({
-		headers: {'Authorization': loginToken}
+		headers: {'X-Updater-Auth': loginToken}
 	});
 
 	

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -98,7 +98,7 @@ class IndexController {
 		if(is_null($storedSecret)) {
 			die('updater.secret is undefined in config/config.php. Either browse the admin settings in your ownCloud and click "Open updater" or define a strong secret using <pre>php -r \'echo password_hash("MyStrongSecretDoUseYourOwn!", PASSWORD_DEFAULT)."\n";\'</pre> and set this in the config.php.');
 		}
-		$sentAuthHeader = ($this->request->header('Authorization') !== null) ? $this->request->header('Authorization') : '';
+		$sentAuthHeader = ($this->request->header('X_Updater_Auth') !== null) ? $this->request->header('X_Updater_Auth') : '';
 
 		if(password_verify($sentAuthHeader, $storedSecret)) {
 			return true;


### PR DESCRIPTION
PHP used in CGI mode will eat the Authorization header and thus the authentication never worked.

Fixes https://github.com/owncloud/updater/issues/263
Requires https://github.com/owncloud/core/pull/22889

@karlitschek I recommend that we merge this for 9.0.0. Otherwise the updater app will not work for people that use PHP in CGI mode.