### PR TITLE
Chdir to updater directory before taking any other action

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -30,12 +30,15 @@ if (version_compare(PHP_VERSION, '5.4.0') === -1){
 
 // symlinks are not resolved by PHP properly
 // getcwd always reports source and not target
-if (isset($_SERVER['PWD'])){
+ if(getcwd()){
+	define('CURRENT_DIR', getcwd());
+} elseif (isset($_SERVER['PWD'])){
 	define('CURRENT_DIR', $_SERVER['PWD']);
 } elseif (isset($_SERVER['SCRIPT_FILENAME'])){
 	define('CURRENT_DIR', dirname($_SERVER['SCRIPT_FILENAME']));
 } else {
-	define('CURRENT_DIR', getcwd());
+	echo 'Failed to detect current directory';
+	exit(1);
 }
 
 session_start();

--- a/application.php
+++ b/application.php
@@ -20,8 +20,16 @@
  *
  */
 
+$oldWorkingDir = getcwd();
+if ($oldWorkingDir === false) {
+	echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+	echo "Can't determine current working dir - the script will continue to work but be aware of the above fact." . PHP_EOL;
+} else if ($oldWorkingDir !== __DIR__ && !chdir(__DIR__)) {
+	echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
+	echo "Can't change to ownCloud root directory." . PHP_EOL;
+	exit(1);
+}
 require __DIR__ . '/app/bootstrap.php';
-
 /** @var \Owncloud\Updater\Console\Application $application */
 $application = $container['application'];
 $application->run();


### PR DESCRIPTION
Fixes misuses like in 
```
www-data@tools01:~/owncloud$ php updater/application.php upgrade:checkpoint -h
PHP Warning: include(/var/www/version.php): failed to open stream: No such file or directory in /var/www/owncloud/updater/src/Utils/Locator.php on line 182
PHP Warning: include(): Failed opening '/var/www/version.php' for inclusion (include_path='.:/usr/share/php:/usr/share/pear') in /var/www/owncloud/updater/src/Utils/Locator.php on line 182
PHP Notice: Undefined variable: OC_Version in /var/www/owncloud/updater/src/Utils/Locator.php on line 185
PHP Warning: implode(): Invalid arguments passed in /var/www/owncloud/updater/src/Console/Application.php on line 148
```