### PR TITLE
Fix config.sample.php in oc root dir after restoring a checkpoint

### DIFF
--- a/src/Command/ExecuteCoreUpgradeScriptsCommand.php
+++ b/src/Command/ExecuteCoreUpgradeScriptsCommand.php
@@ -89,7 +89,6 @@ class ExecuteCoreUpgradeScriptsCommand extends Command {
 			$tmpDir = $locator->getExtractionBaseDir() . '/' . $installedVersion;
 			$fsHelper->removeIfExists($tmpDir);
 			$fsHelper->mkdir($tmpDir);
-			$fsHelper->mkdir($tmpDir . '/config');
 			$oldSourcesDir = $locator->getOwncloudRootPath();
 			$newSourcesDir = $fullExtractionPath . '/owncloud';
 
@@ -97,6 +96,8 @@ class ExecuteCoreUpgradeScriptsCommand extends Command {
 				$this->getApplication()->getLogger()->debug('Replacing ' . $dir);
 				$fsHelper->tripleMove($oldSourcesDir, $newSourcesDir, $tmpDir, $dir);
 			}
+			
+			$fsHelper->copyr($tmpDir . '/config/config.php', $oldSourcesDir . '/config/config.php');
 			
 			try {
 				$fsHelper->move($oldSourcesDir . '/apps', $oldSourcesDir . '/__apps');

--- a/src/Utils/Checkpoint.php
+++ b/src/Utils/Checkpoint.php
@@ -155,7 +155,7 @@ class Checkpoint {
 	 * Return array of all checkpoint ids
 	 * @return array
 	 */
-	protected function getAllCheckpointIds(){
+	public function getAllCheckpointIds(){
 		$checkpointDir = $this->locator->getCheckpointDir();
 		$content = $this->fsHelper->isDir($checkpointDir) ? $this->fsHelper->scandir($checkpointDir) : [];
 		$checkpoints = array_filter(
@@ -182,7 +182,7 @@ class Checkpoint {
 	 * @param string $checkpointId id of checkpoint
 	 * @return string
 	 */
-	protected function getCheckpointPath($checkpointId){
+	public function getCheckpointPath($checkpointId){
 		return $this->locator->getCheckpointDir() . '/' . $checkpointId;
 	}
 

--- a/src/Utils/Locator.php
+++ b/src/Utils/Locator.php
@@ -57,7 +57,7 @@ class Locator {
 	public function getRootDirContent(){
 		return [
 			"3rdparty",
-			"config/config.sample.php",
+			"config",
 			"core",
 			"l10n",
 			"lib",


### PR DESCRIPTION
Reproduction steps
1. php updater/application upgrade:checkpoint --create
2. php updater/application upgrade:checkpoint --restore _checkpointId_
3. php occ integrity:check-core

Expected `config.sample.php` in `config` dir

Actual `config.sample.php` in OC root dir
