### PR TITLE
[Stable8.2] check info xml

### DIFF
--- a/lib/location/apps.php
+++ b/lib/location/apps.php
@@ -58,7 +58,7 @@ class Apps extends Location {
 		$dh = opendir($dir);
 		if (is_resource($dh)) {
 			while (($file = readdir($dh)) !== false) {
-				if ($file[0] !== '.' && is_file($dir . '/' . $file . '/appinfo/app.php')) {
+				if ($file[0] !== '.' && is_file($dir . '/' . $file . '/appinfo/info.xml')) {
 					$this->appsToUpdate[$file] =  $file;
 					if ($dryRun){
 						$result['old'][$file] = realpath($dir . '/' . $file);


### PR DESCRIPTION
Fixes `Signature data not found` https://github.com/owncloud/updater/issues/379#issuecomment-249152842
 when migrating to 9.0.5