### PR TITLE
Use --key=value notation for CLI

### DIFF
--- a/src/Utils/OccRunner.php
+++ b/src/Utils/OccRunner.php
@@ -55,7 +55,7 @@ class OccRunner {
 			$cmdLine = trim($command . ' ' . $extra);
 			foreach ($args as $optionTitle => $optionValue){
 				if (strpos($optionTitle, '--') === 0){
-					$line = trim("$optionTitle $optionValue");
+					$line = trim("$optionTitle=$optionValue");
 				} else {
 					$line = $optionValue;
 				}


### PR DESCRIPTION
Fixes https://github.com/owncloud/updater/issues/383
To test try to start update from CLI on master/stable9.1/stable9

```
$ php updater/application.php upgrade:start
```
The result is `Symfony\Component\Process\Exception\ProcessFailedException` 