### PR TITLE
Fix integrity when migrating from 9.1.0-9.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ sudo: false
 
 php:
   - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
-  - 7
 
 branches:
   only:
@@ -14,18 +10,26 @@ branches:
     - /^stable\d+(\.\d+)?$/
 
 script:
+  # Install dev dependencies
+  - composer require --dev phpunit/phpunit ^4.8
+
   # Test lint
   - find . -name \*.php -exec php -l "{}" \;
 
   # Run phpunit tests
   - cd src/Tests
-  - phpunit --configuration phpunit.xml
+  - ../../vendor/bin/phpunit --configuration phpunit.xml
 
   # Create coverage report
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi"
   
 matrix:
-  allow_failures:
-    - php: hhvm
+matrix:
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+
   fast_finish: true

--- a/src/Utils/Locator.php
+++ b/src/Utils/Locator.php
@@ -103,6 +103,7 @@ class Locator {
 			'README.md',
 			'.travis.yml',
 			'.scrutinizer.yml',
+			'.gitignore'
 		];
 	}
 


### PR DESCRIPTION
Fixing issue reported at
https://github.com/owncloud/administration/pull/111#issuecomment-283940241

extra file `updater/.gitignore` is left after update from any 9.1.x to 9.1.4