### PR TITLE
Fix integrity when updating from 9.1.x to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
   - 7
 
 branches:
@@ -17,10 +14,13 @@ script:
   # Test lint
   - find . -name \*.php -exec php -l "{}" \;
 
+  # Install dev dependencies
+  - composer require --dev phpunit/phpunit ^5.7
+
   # Run phpunit tests
   - make
   - cd src/Tests
-  - phpunit --configuration phpunit.xml
+  - ../../vendor/bin/phpunit --configuration phpunit.xml
 
   # Create coverage report
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"

--- a/src/Utils/Locator.php
+++ b/src/Utils/Locator.php
@@ -113,6 +113,7 @@ class Locator {
 			'README.md',
 			'.travis.yml',
 			'.scrutinizer.yml',
+			'nbproject',
 		];
 	}
 


### PR DESCRIPTION
Fixing issue reported at https://github.com/owncloud/administration/pull/111#issuecomment-283978146

extra files are left after update from  9.1.x:
```
Results
=======
- core
	- EXTRA_FILE
		- updater/nbproject/project.xml
		- updater/nbproject/project.properties
```