### PR TITLE
Fix integrity when migrating from 9.0 to 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ sudo: false
 
 php:
   - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
-  - 7
 
 branches:
   only:
@@ -14,18 +10,26 @@ branches:
     - /^stable\d+(\.\d+)?$/
 
 script:
+  # Install dev dependencies
+  - composer require --dev phpunit/phpunit ^4.8
+
   # Test lint
   - find . -name \*.php -exec php -l "{}" \;
 
   # Run phpunit tests
   - cd src/Tests
-  - phpunit --configuration phpunit.xml
+  - ../../vendor/bin/phpunit --configuration phpunit.xml
 
   # Create coverage report
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi"
   
 matrix:
-  allow_failures:
-    - php: hhvm
+matrix:
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+
   fast_finish: true

--- a/src/Utils/Locator.php
+++ b/src/Utils/Locator.php
@@ -102,6 +102,7 @@ class Locator {
 			'README.md',
 			'.travis.yml',
 			'.scrutinizer.yml',
+			'.gitignore'
 		];
 	}
 

--- a/src/Utils/Locator.php
+++ b/src/Utils/Locator.php
@@ -102,7 +102,8 @@ class Locator {
 			'README.md',
 			'.travis.yml',
 			'.scrutinizer.yml',
-			'.gitignore'
+			'.gitignore',
+			'nbproject',
 		];
 	}
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/updater/pull/416
Reproduction steps:
1. Install 9.0.4
2. Update to 9.0.8 using stable channel 
3. Update to 9.1.4 using daily channel 
4. Do an integrity check:
```
> php occ integr:check-core
  - EXTRA_FILE:
    - updater/.gitignore:
      - expected: 
      - current: 7c017a81ca97f082b0d97869336cd41ad0d02e67de4865e33ca031775dc9ea5e9e7f024a4fa8016e58f29e7c4fd90d1633944ffbab37ee4c4ff739443c8d059c
```

to test:
apply the fix on top of 9.0.8 before updating to 9.1.4

