### PR TITLE
Skip SSL validation for https://localhost

### DIFF
--- a/src/Utils/OccRunner.php
+++ b/src/Utils/OccRunner.php
@@ -115,16 +115,24 @@ class OccRunner {
 	protected function runAsRequest($command, $args){
 		$application = $this->getApplication();
 		$client = new Client();
+		$endpointBase = $application->getEndpoint();
+		$params = [
+			'timeout' => 0,
+			'json' => [
+				'token' => $application->getAuthToken(),
+				'params'=> $args
+			]
+		];
+		
+		// Skip SSL validation for localhost only as localhost never has a valid cert
+		if (preg_match('/^https:\/\/localhost\/.*/i', $endpointBase)){
+			$params['verify'] = false;
+		}
+		
 		$request = $client->createRequest(
 			'POST',
-			$application->getEndpoint() . $command,
-			[
-				'timeout' => 0,
-				'json' => [
-					'token' => $application->getAuthToken(),
-					'params'=> $args
-				]
-			]
+			$endpointBase . $command,
+			$params
 		);
 
 		$response = $client->send($request);


### PR DESCRIPTION
Fixes another case of #414  caused by  forwarding an external port to the LAN device behind NAT.
Testing in progress...