### PR TITLE
[stable9] Skip SSL validation for https://localhost

### DIFF
--- a/src/Utils/OccRunner.php
+++ b/src/Utils/OccRunner.php
@@ -92,16 +92,24 @@ class OccRunner {
 	protected function runAsRequest($command, $args){
 		$application = $this->getApplication();
 		$client = new Client();
+		$endpointBase = $application->getEndpoint();
+		$params = [
+			'timeout' => 0,
+			'json' => [
+				'token' => $application->getAuthToken(),
+				'params'=> $args
+			]
+		];
+		
+		// Skip SSL validation for localhost only as localhost never has a valid cert
+		if (preg_match('/^https:\/\/localhost\/.*/i', $endpointBase)){
+			$params['verify'] = false;
+		}
+		
 		$request = $client->createRequest(
 			'POST',
-			$application->getEndpoint() . $command,
-			[
-				'timeout' => 0,
-				'json' => [
-					'token' => $application->getAuthToken(),
-					'params'=> $args
-				]
-			]
+			$endpointBase . $command,
+			$params
 		);
 
 		$response = $client->send($request);


### PR DESCRIPTION
Backport of https://github.com/owncloud/updater/pull/434

We agreed to backport it to 9.0.x before it reaches EOL as soon as the fix is easy and useful.
This patch was applied by @davitol while testing 9.0.10 to 9.1.6 update in https://github.com/owncloud/administration/pull/139 and is proved to be working
See https://github.com/owncloud/administration/pull/139#issuecomment-331194101