### PR TITLE
Fix for updater/application.php cli fatal errors #472 #482 owncloud/core#31425 

### DIFF
--- a/src/Utils/ConfigReader.php
+++ b/src/Utils/ConfigReader.php
@@ -106,7 +106,7 @@ class ConfigReader {
 	 * @throws \UnexpectedValueException
 	 */
 	private function load(){
-		$this->cache = $this->occRunner->runJson('config:list', ['--private' => '']);
+		$this->cache = $this->occRunner->runJson('config:list', ['--private']);
 		$this->isLoaded = true;
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description

As reported in several issues, running "php updater/application.php upgrade:detect/info" results in a fatal error. 

Traced issue to an unnecessary/fatal "=" in the command line being provided to "php occ" by ConfigReader.php:109. I am unsure if the issue is with the original change of this code to its current revision (https://github.com/owncloud/updater/commit/f78291eb7651d552bf518b30e195b807746da4b5#diff-ad6d84de30f605974920c65454932957 ) or if the issue is one of a Symfony framework change. 

The root issue appears to be Symfony\Component\Process\Process by way of occRunner->runJson interpreting the array as a key-value pair with an empty argument. This results in the argument to "occ" changing from '--private' to '--private=' ... resulting in a fatal error in "occ" and thus a fatal error in "updater/application.php". 

Example cmd line:    [commandline:Symfony\Component\Process\Process:private] => php /path/occ --no-warnings config:list --output=json '--private='

Nevertheless, changing ConfigReader.php:109 to simply remove the associative array assignment of an empty string (e.g. ** => '' **) appears to fix the issue. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #472, #482, possibly #453 (100% untested by me on this particular issue), and owncloud/core#31425 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I am unsure when this actually stopped working - presumably, when the original commit was made 2 years ago, it worked. My only guess is a regression and/or change in the Symfony framework process code -- or a commit/change to "occ" to make it perform more strict command line argument testing.

This proposed pull fixes the immediate issues with updater/application.php being 99.9% broken -- however, there may be other regressions/effects by the ultimate root cause that was the source of this. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment 1: Ubuntu 16.04/PHP 7.0/Owncloud 10.0.9 Stable
- test environment 2: Ubuntu 18.04/PHP 7.2/Owncloud 10.0.9 Stable
- test case 1: run "sudo -u www-data php updater/application.php upgrade:info" 
- test result 1: it works! no more fatal error. 
- other impacts: I do not believe this would impact other code since it only changes one function in the updater


## Screenshots (if appropriate):

**See issues for details.**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [#] Code changes
- [?] Unit tests added 
- [?] Acceptance tests added
- [?] Documentation ticket raised: <link> 
**Do we really need the above for this?** 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [X] Backport (if applicable set "backport-request" label and remove when the backport was done)
