### PR TITLE
Update Travis config to drop PHP 7.0 and add PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
-sudo: false
+os: linux
+dist: xenial
 
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 branches:
   only:
@@ -27,5 +28,5 @@ script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi"
   
-matrix:
+jobs:
   fast_finish: true


### PR DESCRIPTION
Same as PR #541 
Update PHP matrix and fix some travis complaints:
```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing dist, using the default xenial
root: missing os, using the default linux
root: key matrix is an alias for jobs, using jobs
```