### PR TITLE
[tests-only] [full-ci] Run phan with php 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -51,7 +51,14 @@ config = {
             "enableApp": False,
         },
     },
-    "phan": True,
+    "phan": {
+        "multipleVersions": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "phplint": True,
     "phpunit": {
         "allDatabases": {

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "phan/phan": "^5.2"
+    "phan/phan": "^5.4"
   }
 }


### PR DESCRIPTION
`phan` will report errors if any of the code is not compatible with PHP 7.3.

This app still supports PHP 7.3 when used with oC10 core 10.11 and earlier.
