### PR TITLE
org with com replaced

### DIFF
--- a/src/Utils/DocLink.php
+++ b/src/Utils/DocLink.php
@@ -27,7 +27,7 @@ namespace Owncloud\Updater\Utils;
  * @package Owncloud\Updater\Utils
  */
 class DocLink {
-	public const BASE_DOC_URL = 'https://doc.owncloud.org/server';
+	public const BASE_DOC_URL = 'https://doc.owncloud.com/server';
 
 	private $version;
 

--- a/tests/unit/Utils/DocLinkTest.php
+++ b/tests/unit/Utils/DocLinkTest.php
@@ -12,7 +12,7 @@ use Owncloud\Updater\Utils\DocLink;
 class DocLinkTest extends \PHPUnit\Framework\TestCase {
 	public function testGetServerUrl() {
 		// This test constructs strings, from version and relative part and compares that
-		// construct with the expected result. It does not check our actual servers. 
+		// construct with the expected result. It does not check our actual servers.
 		$expected = 'https://doc.owncloud.com/server/10.12/admin_manual/installation/installation_wizard.html#strong-perms-label';
 
 		$version = '10.12';

--- a/tests/unit/Utils/DocLinkTest.php
+++ b/tests/unit/Utils/DocLinkTest.php
@@ -11,7 +11,7 @@ use Owncloud\Updater\Utils\DocLink;
  */
 class DocLinkTest extends \PHPUnit\Framework\TestCase {
 	public function testGetServerUrl() {
-		$expected = 'https://doc.owncloud.org/server/9.0/admin_manual/installation/installation_wizard.html#strong-perms-label';
+		$expected = 'https://doc.owncloud.com/server/9.0/admin_manual/installation/installation_wizard.html#strong-perms-label';
 
 		$version = '9.0';
 		$relativePart = 'installation/installation_wizard.html#strong-perms-label';
@@ -25,9 +25,9 @@ class DocLinkTest extends \PHPUnit\Framework\TestCase {
 	 */
 	public function versionDataProvider() {
 		return [
-			[ '1.2.3.4', 'https://doc.owncloud.org/server/1.2/admin_manual/' ],
-			[ '41.421.31.4.7.5.5', 'https://doc.owncloud.org/server/41.421/admin_manual/' ],
-			[ '42.24', 'https://doc.owncloud.org/server/42.24/admin_manual/' ],
+			[ '1.2.3.4', 'https://doc.owncloud.com/server/1.2/admin_manual/' ],
+			[ '41.421.31.4.7.5.5', 'https://doc.owncloud.com/server/41.421/admin_manual/' ],
+			[ '42.24', 'https://doc.owncloud.com/server/42.24/admin_manual/' ],
 		];
 	}
 

--- a/tests/unit/Utils/DocLinkTest.php
+++ b/tests/unit/Utils/DocLinkTest.php
@@ -11,9 +11,9 @@ use Owncloud\Updater\Utils\DocLink;
  */
 class DocLinkTest extends \PHPUnit\Framework\TestCase {
 	public function testGetServerUrl() {
-		$expected = 'https://doc.owncloud.com/server/9.0/admin_manual/installation/installation_wizard.html#strong-perms-label';
+		$expected = 'https://doc.owncloud.com/server/10.12/admin_manual/installation/installation_wizard.html#strong-perms-label';
 
-		$version = '9.0';
+		$version = '10.12';
 		$relativePart = 'installation/installation_wizard.html#strong-perms-label';
 
 		$docLink = new DocLink($version);

--- a/tests/unit/Utils/DocLinkTest.php
+++ b/tests/unit/Utils/DocLinkTest.php
@@ -11,6 +11,8 @@ use Owncloud\Updater\Utils\DocLink;
  */
 class DocLinkTest extends \PHPUnit\Framework\TestCase {
 	public function testGetServerUrl() {
+		// This test constructs strings, from version and relative part and compares that
+		// construct with the expected result. It does not check our actual servers. 
 		$expected = 'https://doc.owncloud.com/server/10.12/admin_manual/installation/installation_wizard.html#strong-perms-label';
 
 		$version = '10.12';

--- a/tests/unit/Utils/FetcherTest.php
+++ b/tests/unit/Utils/FetcherTest.php
@@ -49,7 +49,7 @@ class FetcherTest extends TestCase {
 	public function testGetValidFeed() {
 		$responseMock = $this->getResponseMock('<?xml version="1.0"?><owncloud>  <version>8.1.3.0</version><versionstring>ownCloud 8.1.3</versionstring>
   <url>https://download.owncloud.org/community/owncloud-8.1.3.zip</url>
-  <web>https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html</web>
+  <web>https://doc.owncloud.com/server/next/admin_manual/maintenance/upgrading/upgrade.html</web>
 </owncloud>');
 		$this->httpClient
 				->method('request')


### PR DESCRIPTION
All doc.owncloud.org replaced with useable doc.owncloud.com links. This also changes some tests. This is probably too much. Let's see...