### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/src/Command/BackupDataCommand.php
+++ b/src/Command/BackupDataCommand.php
@@ -40,7 +40,10 @@ class BackupDataCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->writeln('upgrade:backupData command is not implemented');
+		return 1;
 	}
 }

--- a/src/Command/BackupDbCommand.php
+++ b/src/Command/BackupDbCommand.php
@@ -40,7 +40,10 @@ class BackupDbCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->writeln('upgrade:backupDb command is not implemented');
+		return 1;
 	}
 }

--- a/src/Command/CheckSystemCommand.php
+++ b/src/Command/CheckSystemCommand.php
@@ -45,7 +45,7 @@ class CheckSystemCommand extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$locator = $this->container['utils.locator'];
 		$fsHelper = $this->container['utils.filesystemhelper'];
 		/** @var \Owncloud\Updater\Utils\Registry $registry */

--- a/src/Command/CheckpointCommand.php
+++ b/src/Command/CheckpointCommand.php
@@ -65,9 +65,10 @@ class CheckpointCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 * @throws \Exception
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		\clearstatcache();
 		$checkpoint = $this->container['utils.checkpoint'];
 		if ($input->getOption('create')) {
@@ -85,8 +86,10 @@ class CheckpointCommand extends Command {
 				$output->writeln('Removed checkpoint ' . $checkpointId);
 			} catch (\UnexpectedValueException $e) {
 				$output->writeln($e->getMessage());
+				return 1;
 			} catch (\Exception $e) {
 				$output->writeln('Error while removing a checkpoint ' . $checkpointId);
+				return 1;
 			}
 		} elseif ($input->getOption('restore')) {
 			$checkpointId = \stripslashes($input->getOption('restore'));
@@ -96,8 +99,10 @@ class CheckpointCommand extends Command {
 				$output->writeln('Restored checkpoint ' . $checkpointId);
 			} catch (\UnexpectedValueException $e) {
 				$output->writeln($e->getMessage());
+				return 1;
 			} catch (\Exception $e) {
 				$output->writeln('Error while restoring a checkpoint ' . $checkpointId);
+				return 1;
 			}
 		} else {
 			$checkpoints = $checkpoint->getAll();
@@ -109,5 +114,6 @@ class CheckpointCommand extends Command {
 				$output->writeln('No checkpoints found');
 			}
 		}
+		return 0;
 	}
 }

--- a/src/Command/CleanCacheCommand.php
+++ b/src/Command/CleanCacheCommand.php
@@ -40,7 +40,10 @@ class CleanCacheCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->writeln('upgrade:cleanCache command is not implemented');
+		return 1;
 	}
 }

--- a/src/Command/DetectCommand.php
+++ b/src/Command/DetectCommand.php
@@ -93,7 +93,7 @@ class DetectCommand extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$registry = $this->container['utils.registry'];
 		$registry->set('feed', false);
 
@@ -117,7 +117,7 @@ class DetectCommand extends Command {
 				/* @phan-suppress-next-line PhanUndeclaredMethod */
 				$this->getApplication()->logException($feedData['exception']);
 				// Return a number to stop the queue
-				return $input->getOption('exit-if-none') ? 4 : null;
+				return $input->getOption('exit-if-none') ? 4 : 0;
 			}
 
 			/** @var \Owncloud\Updater\Utils\Feed $feed */
@@ -125,7 +125,7 @@ class DetectCommand extends Command {
 			if (!$feed->isValid()) {
 				// Feed is empty. Means there are no updates
 				$output->writeln('No updates found online.');
-				return $input->getOption('exit-if-none') ? 4 : null;
+				return $input->getOption('exit-if-none') ? 4 : 0;
 			}
 
 			$registry->set('feed', $feed);

--- a/src/Command/ExecuteCoreUpgradeScriptsCommand.php
+++ b/src/Command/ExecuteCoreUpgradeScriptsCommand.php
@@ -63,9 +63,10 @@ class ExecuteCoreUpgradeScriptsCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 * @throws \Exception
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$locator = $this->container['utils.locator'];
 		/** @var FilesystemHelper $fsHelper */
 		$fsHelper = $this->container['utils.filesystemhelper'];
@@ -174,6 +175,7 @@ class ExecuteCoreUpgradeScriptsCommand extends Command {
 				}
 			}
 		}
+		return 0;
 	}
 
 	public function isUpgradeAllowed($installedVersion, $packageVersion, $canBeUpgradedFrom) {

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -42,13 +42,15 @@ class InfoCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$message = \sprintf(
 			'%s %s - CLI based ownCloud server upgrades',
 			$this->getApplication()->getName(),
 			$this->getApplication()->getVersion()
 		);
 		$output->writeln($message);
+		return 0;
 	}
 }

--- a/src/Command/MaintenanceModeCommand.php
+++ b/src/Command/MaintenanceModeCommand.php
@@ -70,8 +70,9 @@ class MaintenanceModeCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$args = [];
 		if ($input->getOption('on')) {
 			$args = ['--on' => ''];
@@ -81,5 +82,6 @@ class MaintenanceModeCommand extends Command {
 
 		$response = $this->occRunner->run('maintenance:mode', $args);
 		$output->writeln($response);
+		return 0;
 	}
 }

--- a/src/Command/PostUpgradeCleanupCommand.php
+++ b/src/Command/PostUpgradeCleanupCommand.php
@@ -40,8 +40,9 @@ class PostUpgradeCleanupCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$registry = $this->container['utils.registry'];
 		$fsHelper = $this->container['utils.filesystemhelper'];
 		$locator = $this->container['utils.locator'];
@@ -80,5 +81,6 @@ class PostUpgradeCleanupCommand extends Command {
 		$registry->clearAll();
 
 		$output->writeln('Done');
+		return 0;
 	}
 }

--- a/src/Command/PostUpgradeRepairCommand.php
+++ b/src/Command/PostUpgradeRepairCommand.php
@@ -40,7 +40,10 @@ class PostUpgradeRepairCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->writeln('upgrade:postUpgradeRepair command is not implemented');
+		return 1;
 	}
 }

--- a/src/Command/PreUpgradeRepairCommand.php
+++ b/src/Command/PreUpgradeRepairCommand.php
@@ -40,7 +40,10 @@ class PreUpgradeRepairCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->writeln('upgrade:preUpgradeRepair command is not implemented');
+		return 1;
 	}
 }

--- a/src/Command/RestartWebServerCommand.php
+++ b/src/Command/RestartWebServerCommand.php
@@ -40,7 +40,10 @@ class RestartWebServerCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->writeln('upgrade:restartWebServer command is not implemented');
+		return 1;
 	}
 }

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -59,8 +59,10 @@ class StartCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
+	 * @throws \Throwable
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$app = $this->getApplication();
 		foreach ($this->stack as $command) {
 			$input = new ArrayInput($command);
@@ -71,5 +73,6 @@ class StartCommand extends Command {
 			}
 		}
 		$output->writeln('Done');
+		return 0;
 	}
 }

--- a/src/Command/UpdateConfigCommand.php
+++ b/src/Command/UpdateConfigCommand.php
@@ -40,7 +40,10 @@ class UpdateConfigCommand extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->writeln('upgrade:updateConfig command is not implemented');
+		return 1;
 	}
 }


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.