### PR TITLE
fix: exit with success command line status 0 for not implemented things

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,27 +7,3 @@ parameters:
       message: '#File ends with a trailing whitespace. This may cause problems when running the code in the web browser. Remove the closing \?\> mark or remove the whitespace.#'
       path:  src/Resources/views/partials/error.php
       count: 1
-    -
-      message: '#Undefined variable: \$OC_Version$#'
-      path: src/Command/ExecuteCoreUpgradeScriptsCommand.php
-      count: 1
-    -
-      message: '#Undefined variable: \$OC_VersionCanBeUpgradedFrom$#'
-      path: src/Command/ExecuteCoreUpgradeScriptsCommand.php
-      count: 1
-    -
-      message: '#Undefined variable: \$CONFIG$#'
-      path: src/Utils/Locator.php
-      count: 2
-    -
-      message: '#Undefined variable: \$OC_Version$#'
-      path: src/Utils/Locator.php
-      count: 1
-    -
-      message: '#Undefined variable: \$OC_Channel$#'
-      path: src/Utils/Locator.php
-      count: 1
-    -
-      message: '#Undefined variable: \$OC_Build$#'
-      path: src/Utils/Locator.php
-      count: 1

--- a/src/Command/BackupDataCommand.php
+++ b/src/Command/BackupDataCommand.php
@@ -44,6 +44,6 @@ class BackupDataCommand extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('upgrade:backupData command is not implemented');
-		return 1;
+		return 0;
 	}
 }

--- a/src/Command/BackupDbCommand.php
+++ b/src/Command/BackupDbCommand.php
@@ -44,6 +44,6 @@ class BackupDbCommand extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('upgrade:backupDb command is not implemented');
-		return 1;
+		return 0;
 	}
 }

--- a/src/Command/CleanCacheCommand.php
+++ b/src/Command/CleanCacheCommand.php
@@ -44,6 +44,6 @@ class CleanCacheCommand extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('upgrade:cleanCache command is not implemented');
-		return 1;
+		return 0;
 	}
 }

--- a/src/Command/PostUpgradeRepairCommand.php
+++ b/src/Command/PostUpgradeRepairCommand.php
@@ -44,6 +44,6 @@ class PostUpgradeRepairCommand extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('upgrade:postUpgradeRepair command is not implemented');
-		return 1;
+		return 0;
 	}
 }

--- a/src/Command/PreUpgradeRepairCommand.php
+++ b/src/Command/PreUpgradeRepairCommand.php
@@ -44,6 +44,6 @@ class PreUpgradeRepairCommand extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('upgrade:preUpgradeRepair command is not implemented');
-		return 1;
+		return 0;
 	}
 }

--- a/src/Command/RestartWebServerCommand.php
+++ b/src/Command/RestartWebServerCommand.php
@@ -44,6 +44,6 @@ class RestartWebServerCommand extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('upgrade:restartWebServer command is not implemented');
-		return 1;
+		return 0;
 	}
 }

--- a/src/Command/UpdateConfigCommand.php
+++ b/src/Command/UpdateConfigCommand.php
@@ -44,6 +44,6 @@ class UpdateConfigCommand extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('upgrade:updateConfig command is not implemented');
-		return 1;
+		return 0;
 	}
 }


### PR DESCRIPTION
PR #711 made sure to return an `int` command line status from all Symfony command `execute` functions.

But it returned `1` for commands that are not yet implemented. That causes scripts to fail if they call any of the not-yet-implemented commands. That has resulted in upgrades failing when they previously worked (albeit with some steps not implemented). Although some steps were not yet implemented, the actual upgrade was working.

This PR changes the command line status to `0` for not-yet-implemented things. `0` is success for the command line. That puts the behavior back to the way it was.

See discussion in issue #726 

Also, remove phpstan ignoreErrors entries for things that are not errors, Recent versions of phpstan no longer have these false positives, so they are no longer needed in `phpstan.neon` - this gets phpstan passing in CI.